### PR TITLE
feat: Add support for server-specific default provider configuration

### DIFF
--- a/cmd/playerpath/internal/config/config.go
+++ b/cmd/playerpath/internal/config/config.go
@@ -4,10 +4,13 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/cetteup/playerpath/internal/domain/provider"
 )
 
 type Config struct {
 	Database DatabaseConfig `yaml:"db"`
+	Servers  []ServerConfig `yaml:"servers"`
 }
 
 type DatabaseConfig struct {
@@ -15,6 +18,11 @@ type DatabaseConfig struct {
 	DatabaseName string `yaml:"dbname"`
 	Username     string `yaml:"user"`
 	Password     string `yaml:"passwd"`
+}
+
+type ServerConfig struct {
+	IP       string            `yaml:"ip"`
+	Provider provider.Provider `yaml:"provider"`
 }
 
 func LoadConfig(path string) (Config, error) {

--- a/cmd/playerpath/internal/handler/verify.go
+++ b/cmd/playerpath/internal/handler/verify.go
@@ -51,7 +51,7 @@ func (h *Handler) HandleGetVerifyPlayer(c echo.Context) error {
 			// If we treat the conflict as a verification failure, neither of the conflicting PID players will pass
 			// By leaving the verification up to the default provider (which should be the provider used by the server),
 			// the provider can (potentially) resolve the conflict based on the `auth` parameter
-			return h.handleForward(c, h.provider)
+			return h.handleForward(c, h.getServerOrDefaultProvider(c.RealIP()))
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError).SetInternal(fmt.Errorf("failed to find player: %w", err))
 	}

--- a/cmd/playerpath/internal/options/options.go
+++ b/cmd/playerpath/internal/options/options.go
@@ -26,7 +26,7 @@ func Init() *Options {
 	flag.BoolVar(&opts.ColorizeLogs, "colorize-logs", false, "colorize log messages")
 	flag.StringVar(&opts.ListenAddr, "address", ":8080", "server/bind address in format [host]:port")
 	flag.StringVar(&opts.ConfigPath, "config", "config.yaml", "path to YAML config file")
-	flag.TextVar(&opts.Provider, "provider", provider.ProviderB2BF2, "primary provider to use as fallback/for directly proxied endpoints (bf2hub|playbf2|openspy|b2bf2)")
+	flag.TextVar(&opts.Provider, "provider", provider.ProviderB2BF2, "provider to use as fallback if one cannot be selected based on player/server (bf2hub|playbf2|openspy|b2bf2)")
 	flag.Parse()
 	return opts
 }

--- a/cmd/playerpath/main.go
+++ b/cmd/playerpath/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cetteup/playerpath/cmd/playerpath/internal/options"
 	"github.com/cetteup/playerpath/internal/database"
 	"github.com/cetteup/playerpath/internal/domain/player/sql"
+	"github.com/cetteup/playerpath/internal/domain/provider"
 )
 
 var (
@@ -67,8 +68,13 @@ func main() {
 		}
 	}()
 
+	servers := make(map[string]provider.Provider, len(cfg.Servers))
+	for _, server := range cfg.Servers {
+		servers[server.IP] = server.Provider
+	}
+
 	repository := sql.NewRepository(db)
-	h := handler.NewHandler(repository, opts.Provider)
+	h := handler.NewHandler(repository, servers, opts.Provider)
 
 	e := echo.New()
 	e.HideBanner = true

--- a/internal/domain/provider/provider.go
+++ b/internal/domain/provider/provider.go
@@ -7,6 +7,7 @@ import (
 type Provider int
 
 const (
+	ProviderUnknown Provider = 0
 	ProviderBF2Hub  Provider = 1
 	ProviderPlayBF2 Provider = 2
 	ProviderOpenSpy Provider = 3
@@ -69,7 +70,7 @@ func (p Provider) RequiresGameSpyHost() bool {
 //goland:noinspection GoMixedReceiverTypes
 func (p *Provider) UnmarshalText(text []byte) error {
 	if len(text) == 0 {
-		*p = 0
+		*p = ProviderUnknown
 		return nil
 	}
 


### PR DESCRIPTION
Eliminates the need to run multiple playerpath instances to support different default providers. Requests are primarily forwarded to the player's provider where possible. If determining the player provider fails, the requesting server's default provider is used. Only if no default provider for that server has been configured do we use the global default provider.